### PR TITLE
parquet outputstream rw

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ lazy val commonSettings = Seq(
   Keys.isSnapshot := true,
   Keys.scalaVersion := "2.11.12",
   Keys.scalacOptions ++= Seq("-deprecation", "-target:jvm-1.8"),
-  Keys.javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-unchecked", "-deprecation", "-feature"),
+//  Keys.javacOptions ++= Seq("-source", "1.8", "-target", "1.8",  "-deprecation", "-feature"),
   Keys.resolvers := resolvers
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ lazy val commonSettings = Seq(
   Keys.isSnapshot := true,
   Keys.scalaVersion := "2.11.12",
   Keys.scalacOptions ++= Seq("-deprecation", "-target:jvm-1.8"),
-//  Keys.javacOptions ++= Seq("-source", "1.8", "-target", "1.8",  "-deprecation", "-feature"),
+  Keys.javacOptions ++= Seq("-source", "1.8", "-target", "1.8","-unchecked",  "-deprecation", "-feature"),
   Keys.resolvers := resolvers
 )
 

--- a/core/src/it/scala/com/github/mjakubowski84/parquet4s/ParquetStreamWriter.scala
+++ b/core/src/it/scala/com/github/mjakubowski84/parquet4s/ParquetStreamWriter.scala
@@ -1,0 +1,40 @@
+package com.github.mjakubowski84.parquet4s
+
+import java.io.{ByteArrayOutputStream, FileOutputStream}
+
+import org.scalatest.{BeforeAndAfter, FreeSpec, Matchers}
+
+case class Test(
+                 t: String,
+                 f: Option[Int]
+               )
+class ParquetStreamWriter extends FreeSpec
+with Matchers
+with BeforeAndAfter with SparkHelper {
+  import sparkSession.implicits._
+
+
+  "write parquet to outputstream" - {
+    val data = Seq(Test("a", None), Test("b", Some(1)))
+    val outputStream = new ByteArrayOutputStream()
+    val outfile = new StreamOutputFile(outputStream)
+    import ParquetWriter._
+    ParquetWriter.writeS(outfile,data)
+    outputStream.close()
+    println(outputStream)
+    outputStream.size() > 1 should equal(true)
+  }
+
+  "spark read data written to file from outputstream" - {
+    val data = Seq(Test("a", None), Test("b", Some(1)))
+    val outputStream = new ByteArrayOutputStream()
+    val outfile = new StreamOutputFile(outputStream)
+    ParquetWriter.writeS(outfile,data)
+    outputStream.close()
+    val f = new FileOutputStream(tempPathString)
+    f.write(outputStream.toByteArray)
+    f.close()
+    sparkSession.read.parquet(tempPathString).as[Test].collect().toSeq should equal(data)
+  }
+
+}

--- a/core/src/it/scala/com/github/mjakubowski84/parquet4s/ParquetStreamWriterSpec.scala
+++ b/core/src/it/scala/com/github/mjakubowski84/parquet4s/ParquetStreamWriterSpec.scala
@@ -8,7 +8,7 @@ case class Test(
                  t: String,
                  f: Option[Int]
                )
-class ParquetStreamWriter extends FreeSpec
+class ParquetStreamWriterSpec extends FreeSpec
 with Matchers
 with BeforeAndAfter with SparkHelper {
   import sparkSession.implicits._

--- a/core/src/main/java/com/github/mjakubowski84/parquet4s/InputFileBuilder.java
+++ b/core/src/main/java/com/github/mjakubowski84/parquet4s/InputFileBuilder.java
@@ -1,0 +1,18 @@
+package com.github.mjakubowski84.parquet4s;
+
+import org.apache.parquet.io.InputFile;
+import org.apache.parquet.hadoop.api.ReadSupport;
+
+public class InputFileBuilder<T> extends org.apache.parquet.hadoop.ParquetReader.Builder<T> {
+    private final ReadSupport<T> readSupport;
+
+     InputFileBuilder(InputFile file, ReadSupport<T> readerSupport) {
+       super(file);
+        this.readSupport = readerSupport;
+    }
+
+    @Override
+    protected ReadSupport<T> getReadSupport() {
+        return readSupport;
+    }
+}

--- a/core/src/main/java/com/github/mjakubowski84/parquet4s/OutputStream.java
+++ b/core/src/main/java/com/github/mjakubowski84/parquet4s/OutputStream.java
@@ -1,7 +1,6 @@
 package com.github.mjakubowski84.parquet4s;
 
 import org.apache.parquet.io.DelegatingPositionOutputStream;
-import org.apache.parquet.io.PositionOutputStream;
 
 import java.io.IOException;
 

--- a/core/src/main/java/com/github/mjakubowski84/parquet4s/OutputStream.java
+++ b/core/src/main/java/com/github/mjakubowski84/parquet4s/OutputStream.java
@@ -1,0 +1,48 @@
+package com.github.mjakubowski84.parquet4s;
+
+import org.apache.parquet.io.DelegatingPositionOutputStream;
+import org.apache.parquet.io.PositionOutputStream;
+
+import java.io.IOException;
+
+public class OutputStream extends DelegatingPositionOutputStream {
+    private long position = 0;
+    private java.io.OutputStream outputStream;
+
+    public OutputStream(java.io.OutputStream outputStream) {
+        super(outputStream);
+        this.outputStream = outputStream;
+    }
+
+    @Override
+    public long getPos() throws IOException {
+        return position;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        position++;
+        outputStream.write(b);
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+        write(b, 0, b.length);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        outputStream.write(b, off, len);
+        position += len;
+    }
+
+    @Override
+    public void flush() throws IOException {
+        outputStream.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+        outputStream.close();
+    }
+}

--- a/core/src/main/java/com/github/mjakubowski84/parquet4s/StreamInputFile.java
+++ b/core/src/main/java/com/github/mjakubowski84/parquet4s/StreamInputFile.java
@@ -1,0 +1,29 @@
+package com.github.mjakubowski84.parquet4s;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.parquet.io.InputFile;
+import org.apache.parquet.io.SeekableInputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class StreamInputFile implements InputFile {
+    private long length;
+    private byte[] in;
+
+    public StreamInputFile(byte[] in) {
+        this.length = in.length;
+        this.in = in;
+    }
+
+    @Override
+    public long getLength() throws IOException {
+        return length;
+    }
+
+    @Override
+    public SeekableInputStream newStream() throws IOException {
+        return new StreamSeekable(new ByteArrayInputStream(in));
+    }
+}

--- a/core/src/main/java/com/github/mjakubowski84/parquet4s/StreamInputFile.java
+++ b/core/src/main/java/com/github/mjakubowski84/parquet4s/StreamInputFile.java
@@ -1,12 +1,10 @@
 package com.github.mjakubowski84.parquet4s;
 
-import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.parquet.io.InputFile;
 import org.apache.parquet.io.SeekableInputStream;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 
 public class StreamInputFile implements InputFile {
     private long length;

--- a/core/src/main/java/com/github/mjakubowski84/parquet4s/StreamOutputFile.java
+++ b/core/src/main/java/com/github/mjakubowski84/parquet4s/StreamOutputFile.java
@@ -1,0 +1,36 @@
+package com.github.mjakubowski84.parquet4s;
+
+import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.io.PositionOutputStream;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class StreamOutputFile implements OutputFile {
+    private OutputStream outputStream;
+
+    public StreamOutputFile(OutputStream outputStream) {
+        this.outputStream = outputStream;
+    }
+
+    @Override
+    public PositionOutputStream create(long blockSizeHint) throws IOException {
+        return new com.github.mjakubowski84.parquet4s.OutputStream(outputStream);
+    }
+
+    @Override
+    public PositionOutputStream createOrOverwrite(long blockSizeHint) throws IOException {
+        return new com.github.mjakubowski84.parquet4s.OutputStream(outputStream);
+    }
+
+    @Override
+    public boolean supportsBlockSize() {
+        return false;
+    }
+
+    @Override
+    public long defaultBlockSize() {
+        return 0;
+    }
+}

--- a/core/src/main/java/com/github/mjakubowski84/parquet4s/StreamSeekable.java
+++ b/core/src/main/java/com/github/mjakubowski84/parquet4s/StreamSeekable.java
@@ -1,0 +1,128 @@
+package com.github.mjakubowski84.parquet4s;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.PositionedReadable;
+import org.apache.hadoop.fs.Seekable;
+import org.apache.parquet.io.DelegatingSeekableInputStream;
+import org.apache.parquet.io.SeekableInputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+//public class StreamSeekable extends DelegatingSeekableInputStream {
+//
+//    private long position = 0;
+//    private FSDataInputStream stream;
+//
+//    public StreamSeekable(FSDataInputStream inputStream) {
+//        super(inputStream);
+//        this.stream = inputStream;
+//    }
+//
+//    @Override
+//    public long getPos() throws IOException {
+//        return stream.getPos();
+//    }
+//
+//    @Override
+//    public void seek(long newPos) throws IOException {
+//        stream.seek(newPos);
+//    }
+//
+//    @Override
+//    public void readFully(byte[] bytes) throws IOException {
+//        stream.readFully(bytes, 0, bytes.length);
+//    }
+//
+//    @Override
+//    public void readFully(byte[] bytes, int start, int len) throws IOException {
+//        stream.readFully(bytes);
+//    }
+//}
+
+public class StreamSeekable extends DelegatingSeekableInputStream implements Seekable,
+        PositionedReadable {
+
+    private ByteArrayInputStream inputStream;
+    private long pos;
+
+    public StreamSeekable(ByteArrayInputStream in) {
+        super(in);
+        this.inputStream = in ;//new ByteArrayInputStream(recommendationBytes);
+        pos = 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void seek(long pos) throws IOException {
+        inputStream.skip(pos);
+        this.pos = pos;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getPos() throws IOException {
+        return pos;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean seekToNewSource(long targetPos) throws IOException {
+        throw new UnsupportedOperationException("seekToNewSource is not supported.");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int read() throws IOException {
+        int val = inputStream.read();
+        if (val > 0) {
+            pos++;
+        }
+        return val;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int read(long position, byte[] buffer, int offset, int length) throws IOException {
+        long currPos = pos;
+        inputStream.skip(position);
+        int bytesRead = inputStream.read(buffer, offset, length);
+        inputStream.skip(currPos);
+        return bytesRead;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void readFully(long position, byte[] buffer, int offset, int length) throws IOException {
+        long currPos = pos;
+        inputStream.skip(position);
+        inputStream.read(buffer, offset, length);
+        inputStream.skip(currPos);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void readFully(long position, byte[] buffer) throws IOException {
+        long currPos = pos;
+        inputStream.skip(position);
+        inputStream.read(buffer);
+        inputStream.skip(currPos);
+    }
+
+}

--- a/core/src/main/java/com/github/mjakubowski84/parquet4s/StreamSeekable.java
+++ b/core/src/main/java/com/github/mjakubowski84/parquet4s/StreamSeekable.java
@@ -1,46 +1,11 @@
 package com.github.mjakubowski84.parquet4s;
 
-import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.PositionedReadable;
 import org.apache.hadoop.fs.Seekable;
 import org.apache.parquet.io.DelegatingSeekableInputStream;
-import org.apache.parquet.io.SeekableInputStream;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.ByteBuffer;
-
-//public class StreamSeekable extends DelegatingSeekableInputStream {
-//
-//    private long position = 0;
-//    private FSDataInputStream stream;
-//
-//    public StreamSeekable(FSDataInputStream inputStream) {
-//        super(inputStream);
-//        this.stream = inputStream;
-//    }
-//
-//    @Override
-//    public long getPos() throws IOException {
-//        return stream.getPos();
-//    }
-//
-//    @Override
-//    public void seek(long newPos) throws IOException {
-//        stream.seek(newPos);
-//    }
-//
-//    @Override
-//    public void readFully(byte[] bytes) throws IOException {
-//        stream.readFully(bytes, 0, bytes.length);
-//    }
-//
-//    @Override
-//    public void readFully(byte[] bytes, int start, int len) throws IOException {
-//        stream.readFully(bytes);
-//    }
-//}
 
 public class StreamSeekable extends DelegatingSeekableInputStream implements Seekable,
         PositionedReadable {
@@ -50,7 +15,7 @@ public class StreamSeekable extends DelegatingSeekableInputStream implements See
 
     public StreamSeekable(ByteArrayInputStream in) {
         super(in);
-        this.inputStream = in ;//new ByteArrayInputStream(recommendationBytes);
+        this.inputStream = in ;
         pos = 0;
     }
 

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetReader.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetReader.scala
@@ -21,6 +21,12 @@ trait ParquetReader[T] {
     */
   def read(path: String, options: ParquetReader.Options): ParquetIterable[T]
 
+  /**
+    * Reads data from given input file stream
+    * @param inputStream Stream
+    * @param options configuration of how Parquet files should be read
+    * @return iterable collection of data read from path
+    */
   def readS(inputStream: InputFile, options: ParquetReader.Options): ParquetIterable[T]
 
 
@@ -68,6 +74,14 @@ object ParquetReader {
   def read[T](path: String, options: Options = Options())(implicit reader: ParquetReader[T]): ParquetIterable[T] =
     reader.read(path, options)
 
+  /**
+    * Creates a new [[ParquetIterable]] over the data from the input stream
+    * @param inputFile Wrapper over input stream
+    * @param options configuration of how Parquet files should be read
+    * @param reader
+    * @tparam T
+    * @return
+    */
   def readS[T](inputFile: InputFile, options: Options = Options())(implicit reader: ParquetReader[T]): ParquetIterable[T] =
     reader.readS(inputFile, options)
 

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetReader.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetReader.scala
@@ -5,6 +5,7 @@ import java.util.TimeZone
 
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.hadoop.{ParquetReader => HadoopParquetReader}
+import org.apache.parquet.io.InputFile
 
 /**
   * Type class that reads Parquet files from given path.
@@ -19,6 +20,9 @@ trait ParquetReader[T] {
     * @return iterable collection of data read from path
     */
   def read(path: String, options: ParquetReader.Options): ParquetIterable[T]
+
+  def readS(inputStream: InputFile, options: ParquetReader.Options): ParquetIterable[T]
+
 
 }
 
@@ -42,6 +46,9 @@ object ParquetReader {
   private def newParquetIterable[T : ParquetRecordDecoder](path: String, options: Options): ParquetIterable[T] =
     newParquetIterable(HadoopParquetReader.builder[RowParquetRecord](new ParquetReadSupport(), new Path(path)), options)
 
+  private def newParquetIterable[T : ParquetRecordDecoder](inputFile: InputFile, options: Options): ParquetIterable[T] =
+    newParquetIterable(new InputFileBuilder[RowParquetRecord](inputFile, new ParquetReadSupport()), options)
+
   private[parquet4s] def newParquetIterable[T : ParquetRecordDecoder](builder: Builder, options: Options): ParquetIterable[T] =
     new ParquetIterableImpl(builder, options)
 
@@ -61,11 +68,16 @@ object ParquetReader {
   def read[T](path: String, options: Options = Options())(implicit reader: ParquetReader[T]): ParquetIterable[T] =
     reader.read(path, options)
 
+  def readS[T](inputFile: InputFile, options: Options = Options())(implicit reader: ParquetReader[T]): ParquetIterable[T] =
+    reader.readS(inputFile, options)
+
   /**
     * Default implementation of [[ParquetReader]].
     */
   implicit def reader[T : ParquetRecordDecoder]: ParquetReader[T] = new ParquetReader[T] {
     override def read(path: String, options: Options = Options()): ParquetIterable[T] = newParquetIterable(path, options)
+
+    override def readS(inputStream: InputFile, options: Options): ParquetIterable[T] = newParquetIterable(inputStream, options)
   }
 
 }

--- a/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetWriter.scala
+++ b/core/src/main/scala/com/github/mjakubowski84/parquet4s/ParquetWriter.scala
@@ -31,6 +31,12 @@ trait ParquetWriter[T] {
     */
   def write(path: String, data: Iterable[T], options: ParquetWriter.Options)
 
+  /**
+    * Writes data out to given OutputFile
+    * @param outputFile a stream representation
+    * @param data data to write
+    * @param options configuration of how Parquet files should be created and written
+    */
   def writeS(outputFile: OutputFile, data: Iterable[T], options: ParquetWriter.Options): Unit
 
 }
@@ -106,7 +112,7 @@ object ParquetWriter  {
       .withPageSize(options.pageSize)
       .withRowGroupSize(options.rowGroupSize)
       .withValidation(options.validationEnabled)
-    .withWriterVersion(WriterVersion.PARQUET_1_0)
+      .withWriterVersion(WriterVersion.PARQUET_1_0)
       .build()
 
   /**
@@ -122,6 +128,15 @@ object ParquetWriter  {
   def write[T](path: String, data: Iterable[T], options: ParquetWriter.Options = ParquetWriter.Options())
               (implicit writer: ParquetWriter[T]): Unit = writer.write(path, data, options)
 
+  /**
+    * Writes an iterable collection of data as a Parquet object.
+    * OutputFile wraps an outputstream.
+    * @param outputFile Wrapper for output stream to write to
+    * @param data collection of <i>T</i> that will be written as a Parquet in memory object
+    * @param options configuration of how Parquet files should be created and written
+    * @param writer [[ParquetWriter]] that will be used to write data
+    * @tparam T   type of data, will be used also to resolve the schema of Parquet files
+    */
   def writeS[T](outputFile: OutputFile, data: Iterable[T], options: ParquetWriter.Options = ParquetWriter.Options())
               (implicit writer: ParquetWriter[T]): Unit = writer.writeS(outputFile, data, options)
 


### PR DESCRIPTION
Updates library with the ability to write parquet files to an outputstream vis `writeS` method. Previously only file writes were available. 

- Required Stream wrapper classes
- Updates to scala traits to all writeS/readS for streams
- updates to integration tests to verify:
    - the ability to write all types to stream
     - the ability for spark to read a file written post write to an output stream (https://github.com/coatue-oss/parquet4s/compare/master...coatue-oss:vd_parquet_outputstream_rw?expand=1#diff-405ae7b8ba3ed5fa0127affbafd63ac1R28)